### PR TITLE
Added an External Links section into the manifest

### DIFF
--- a/Sources/SPIManifest/Manifest.swift
+++ b/Sources/SPIManifest/Manifest.swift
@@ -6,6 +6,7 @@ import Yams
 public struct Manifest: Codable, Equatable {
     public var version: Int = 1
     public var builder: Builder
+    public var externalLinks: ExternalLinks?
 
     public struct Builder: Codable, Equatable {
         public var configs: [BuildConfig]
@@ -42,9 +43,16 @@ public struct Manifest: Codable, Equatable {
         }
     }
 
-    public init(version: Int = 1, builder: Manifest.Builder) {
+    public struct ExternalLinks: Codable, Equatable {
+        public var documentation: String?
+    }
+
+    public init(version: Int = 1,
+                builder: Manifest.Builder,
+                externalLinks: Manifest.ExternalLinks? = nil) {
         self.version = version
         self.builder = builder
+        self.externalLinks = externalLinks
     }
 
     public init(yml: String) throws {

--- a/Sources/SPIManifest/Manifest.swift
+++ b/Sources/SPIManifest/Manifest.swift
@@ -5,7 +5,7 @@ import Yams
 
 public struct Manifest: Codable, Equatable {
     public var version: Int = 1
-    public var builder: Builder
+    public var builder: Builder?
     public var externalLinks: ExternalLinks?
 
     public struct Builder: Codable, Equatable {
@@ -48,7 +48,7 @@ public struct Manifest: Codable, Equatable {
     }
 
     public init(version: Int = 1,
-                builder: Manifest.Builder,
+                builder: Manifest.Builder? = nil,
                 externalLinks: Manifest.ExternalLinks? = nil) {
         self.version = version
         self.builder = builder
@@ -85,6 +85,8 @@ extension Manifest {
     }
 
     public func config(platform: Selection<Platform> = .any, swiftVersion: Selection<SwiftVersion> = .any) -> Builder.BuildConfig? {
+        guard let builder = builder else { return nil }
+
         switch (platform, swiftVersion) {
             case (.any, .any):
                 return builder.configs.first
@@ -125,7 +127,9 @@ extension Manifest {
     }
 
     public func allDocumentationTargets() -> [String]? {
-        Set(
+        guard let builder = builder else { return nil }
+
+        return Set(
             builder.configs.reduce([String]()) { partialResult, config in
                 partialResult + (config.documentationTargets ?? [])
             }
@@ -164,6 +168,8 @@ extension Manifest {
     }
 
     public func scheme(for platform: Platform) -> String? {
+        guard let builder = builder else { return nil }
+
         if let specific = config(platform: .specific(platform))
             .flatMap(\.scheme) {
             return specific
@@ -176,6 +182,8 @@ extension Manifest {
     }
 
     public func target(for platform: Platform) -> String? {
+        guard let builder = builder else { return nil }
+
         if let specific = config(platform: .specific(platform))
             .flatMap(\.target) {
             return specific

--- a/Sources/SPIManifest/Manifest.swift
+++ b/Sources/SPIManifest/Manifest.swift
@@ -8,6 +8,12 @@ public struct Manifest: Codable, Equatable {
     public var builder: Builder?
     public var externalLinks: ExternalLinks?
 
+    enum CodingKeys: String, CodingKey {
+        case version
+        case builder
+        case externalLinks = "external_links"
+    }
+
     public struct Builder: Codable, Equatable {
         public var configs: [BuildConfig]
 

--- a/Tests/SPIManifestTests/ManifestTests.swift
+++ b/Tests/SPIManifestTests/ManifestTests.swift
@@ -7,11 +7,7 @@ import Yams
 class ManifestTests: XCTestCase {
 
     func test_empty() throws {
-        do {
-            let m = try Manifest(yml: "version: 1")
-            XCTAssertNil(m.builder)
-            XCTAssertNil(m.externalLinks)
-        }
+        XCTAssertNoThrow(try Manifest(yml: "version: 1"))
     }
 
     func test_encode_manifest() throws {

--- a/Tests/SPIManifestTests/ManifestTests.swift
+++ b/Tests/SPIManifestTests/ManifestTests.swift
@@ -398,4 +398,17 @@ class ManifestTests: XCTestCase {
         XCTAssertEqual(m?.scheme(for: .ios), "ComposableArchitecture")
     }
 
+    func test_documentationUrl() throws {
+        do {
+            let m = try Manifest(yml: """
+                version: 1
+                external_links:
+                  documentation: https://example.com/package/documentation/
+                """)
+
+            let externalLinks = try XCTUnwrap(m.externalLinks)
+            XCTAssertEqual(externalLinks.documentation, "https://example.com/package/documentation/")
+        }
+    }
+
 }

--- a/Tests/SPIManifestTests/ManifestTests.swift
+++ b/Tests/SPIManifestTests/ManifestTests.swift
@@ -6,6 +6,14 @@ import Yams
 
 class ManifestTests: XCTestCase {
 
+    func test_empty() throws {
+        do {
+            let m = try Manifest(yml: "version: 1")
+            XCTAssertNil(m.builder)
+            XCTAssertNil(m.externalLinks)
+        }
+    }
+
     func test_encode_manifest() throws {
         let m = Manifest(builder: .init(configs: [
             .init(platform: Platform.watchos.rawValue, scheme: "Alamofire watchOS")


### PR DESCRIPTION
I made it a struct in itself because I can see that we'd also want to support other external URLs in the future and didn't want to muddy the base namespace of the manifest.

The biggest change here is that `builder` is now optional. Necessary for package authors who *only* want to add a documentation URL.