### PR TITLE
Reverting back to Yams 4.x to solve the dependency resolution problem

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/jpsim/Yams.git",
         "state": {
           "branch": null,
-          "revision": "01835dc202670b5bb90d07f3eae41867e9ed29f6",
-          "version": "5.0.1"
+          "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
+          "version": "4.0.6"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
         .library(name: "SPIManifest", targets: ["SPIManifest"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/jpsim/Yams.git", from: "5.0.0"),
+        .package(url: "https://github.com/jpsim/Yams.git", from: "4.0.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
The SPM repo on both the `release/5.6` **and** `release/5.7` branches have a dependency on Yams `4.0.0..<4.1.0`. That has been updated to be `5.0.0..<5.1.0` on their `main` branch, but we obviously can't pin to that.

This is one possible solution. All our tests pass and we're not doing anything crazy with YML, so it should be fine until they tag a `release/5.8` branch we can pin to.