### PR TITLE
Accept `macos` as a synonym for `macos-spm`

### DIFF
--- a/Sources/SPIManifest/Manifest.swift
+++ b/Sources/SPIManifest/Manifest.swift
@@ -92,8 +92,10 @@ extension Manifest {
             Current.fileManager.fileExists(path),
             let data = Current.fileManager.contents(path),
             data.count <= maxByteSize,
-            let manifest = try? YAMLDecoder().decode(Self.self, from: data)
+            var manifest = try? YAMLDecoder().decode(Self.self, from: data)
         else { return nil }
+
+        Self.fixPlatforms(manifest: &manifest)
 
         return manifest
     }
@@ -213,4 +215,22 @@ extension Manifest {
             .flatMap(\.target)
     }
 
+}
+
+
+extension Manifest {
+    /// Adjust user provided platform inputs to match valid keys. For instance `macos` (which would need to be `macos-spm` to match `Platform.macosSpm`.
+    /// - Parameter manifest: input `Manifest`
+    private static func fixPlatforms(manifest: inout Manifest) {
+        if let builder = manifest.builder {
+            let configs = builder.configs.map { config in
+                var config = config
+                if config.platform?.lowercased() == "macos" {
+                    config.platform = Platform.macosSpm.rawValue
+                }
+                return config
+            }
+            manifest.builder?.configs = configs
+        }
+    }
 }

--- a/Sources/SPIManifest/Manifest.swift
+++ b/Sources/SPIManifest/Manifest.swift
@@ -223,7 +223,7 @@ extension Manifest {
     /// - Parameter manifest: input `Manifest`
     private static func fixPlatforms(manifest: inout Manifest) {
         if let builder = manifest.builder {
-            let configs = builder.configs.map { config in
+            let configs = builder.configs.map { config -> Builder.BuildConfig in
                 var config = config
                 if config.platform?.lowercased() == "macos" {
                     config.platform = Platform.macosSpm.rawValue

--- a/Tests/SPIManifestTests/ManifestTests.swift
+++ b/Tests/SPIManifestTests/ManifestTests.swift
@@ -440,4 +440,32 @@ class ManifestTests: XCTestCase {
         }
     }
 
+    func test_macos_platform() throws {
+        // Ensure we interpret platform key `macos` as `macos-spm`
+        // https://github.com/SwiftPackageIndex/SPIManifest/issues/11
+        Current.fileManager.fileExists = { _ in true }
+        Current.fileManager.contents = { _ in
+            Data(
+                """
+                version: 1
+                builder:
+                  configs:
+                  - platform: macos
+                    target: foo
+                """.utf8
+            )
+        }
+
+        // MUT
+        let m = Manifest.load()
+
+        // validation
+        XCTAssertEqual(m,
+                       Manifest(builder: .init(configs: [
+                        .init(platform: Platform.macosSpm.rawValue,
+                              target: "foo")
+                       ]))
+        )
+    }
+
 }


### PR DESCRIPTION
Fixes #11 