### PR TITLE
Add spi-manifest-validate executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ DerivedData/
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
 .vscode/
+.swiftpm/

--- a/Package.swift
+++ b/Package.swift
@@ -20,19 +20,15 @@ let package = Package(
     name: "SPIManifest",
     platforms: [.macOS(.v10_15)],
     products: [
+        .executable(name: "spi-manifest-validate", targets: ["Validator"]),
         .library(name: "SPIManifest", targets: ["SPIManifest"]),
     ],
     dependencies: [
         .package(url: "https://github.com/jpsim/Yams.git", "4.0.0"..<"6.0.0"),
     ],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages this package depends on.
-        .target(
-            name: "SPIManifest",
-            dependencies: ["Yams"]),
-        .testTarget(
-            name: "SPIManifestTests",
-            dependencies: ["SPIManifest"]),
+        .executableTarget(name: "Validator", dependencies: ["SPIManifest"]),
+        .target(name: "SPIManifest", dependencies: ["Yams"]),
+        .testTarget(name: "SPIManifestTests", dependencies: ["SPIManifest"]),
     ]
 )

--- a/Sources/SPIManifest/File.swift
+++ b/Sources/SPIManifest/File.swift
@@ -1,0 +1,37 @@
+// Copyright 2020-2022 Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+public enum ManifestError: Error {
+    case fileTooLarge(size: Int)
+    case decodingError(String)
+    case invalidPath(path: String)
+    case noData
+}
+
+
+extension ManifestError: CustomStringConvertible {
+    public var description: String {
+        switch self {
+            case .fileTooLarge(size: let size):
+                return "fileTooLarge"
+            case let .decodingError(message):
+                return "The file could not be decoded: \(message)"
+            case let .invalidPath(path: path):
+                return "Invalid path: \(path)."
+            case .noData:
+                return "The file contains no data."
+        }
+    }
+}

--- a/Sources/SPIManifest/File.swift
+++ b/Sources/SPIManifest/File.swift
@@ -25,7 +25,7 @@ extension ManifestError: CustomStringConvertible {
     public var description: String {
         switch self {
             case .fileTooLarge(size: let size):
-                return "fileTooLarge"
+                return "File is too large: \(size) bytes"
             case let .decodingError(message):
                 return "The file could not be decoded: \(message)"
             case let .invalidPath(path: path):

--- a/Sources/Validator/main.swift
+++ b/Sources/Validator/main.swift
@@ -1,9 +1,10 @@
-import SPIManifest
 #if os(macOS)
 import Darwin
 #elseif os(Linux)
 import Glibc
 #endif
+
+import SPIManifest
 
 
 func main() {

--- a/Sources/Validator/main.swift
+++ b/Sources/Validator/main.swift
@@ -1,5 +1,9 @@
 import SPIManifest
+#if os(macOS)
 import Darwin
+#elseif os(Linux)
+import Glibc
+#endif
 
 
 func main() {

--- a/Sources/Validator/main.swift
+++ b/Sources/Validator/main.swift
@@ -1,0 +1,22 @@
+import SPIManifest
+import Darwin
+
+
+func main() {
+    guard CommandLine.arguments.count == 2,
+    let path = CommandLine.arguments.last else {
+        print("Usage: spi-manifest-validate <.spi.yml file>")
+        exit(1)
+    }
+
+    do {
+        _ = try SPIManifest.Manifest.load(at: path)
+    } catch {
+        print("🔴 \(error)")
+        exit(2)
+    }
+
+    print("✅ The file is valid.")
+}
+
+main()


### PR DESCRIPTION
Add executable to validate spi.yml files:

```
❯ spi-manifest-validate .spi.yml
✅ The file is valid.
~/P/S/spi-manifest on add-validator 
```

```
❯ spi-manifest-validate .spi.yml
🔴 The file could not be decoded: Key not found: 'version'.
```