### PR TITLE
Add support for iOS

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -2,3 +2,4 @@ version: 1
 builder:
   configs:
     - documentation_targets: [SPIManifest]
+      scheme: SPIManifest


### PR DESCRIPTION
This avoids building the plugin, which fails on iOS (and tvOS, watchOS).