### PR TITLE
Ensure docs are built on the latest •release• version, not just the latest version overall

### DIFF
--- a/Sources/SPIManifest/Manifest.swift
+++ b/Sources/SPIManifest/Manifest.swift
@@ -232,7 +232,7 @@ extension Manifest {
         }
 
         // Next, if the Swift version is the latest, try to find a platform match without a fixed Swift version
-        if swiftVersion == .latest,
+        if swiftVersion == .latestRelease,
            let value =  config(platform: .specific(platform), swiftVersion: .none)?[keyPath: keypath] {
             return value
         }
@@ -245,7 +245,7 @@ extension Manifest {
 
         // Finally, if the platform is the preferred docc platform (macosSpm) and the Swift version is the latest, try to find a config match without any platform or Swift version
         if platform == .macosSpm,
-           swiftVersion == .latest,
+           swiftVersion == .latestRelease,
            let value = config(platform: .none, swiftVersion: .none)?[keyPath: keypath] {
             return value
         }

--- a/Sources/SPIManifest/SwiftVersion.swift
+++ b/Sources/SPIManifest/SwiftVersion.swift
@@ -19,14 +19,14 @@ public enum SwiftVersion: ShortVersion, Codable {
     case v5_6 = "5.6"
     case v5_7 = "5.7"
     case v5_8 = "5.8"
-    case v5_9 = "5.9"
+    case v5_9 = "5.9"  // currently a pre-release version
+
+    public static var latestRelease: Self { .v5_8 }
 }
 
 
 extension SwiftVersion: CaseIterable {
-    public static var latest: Self { SwiftVersion.allCases.last! }
-
-    public var isLatest: Bool { self == Self.latest }
+    public var isLatestRelease: Bool { self == Self.latestRelease }
 }
 
 

--- a/Tests/SPIManifestTests/ManifestTests.swift
+++ b/Tests/SPIManifestTests/ManifestTests.swift
@@ -191,7 +191,7 @@ class ManifestTests: XCTestCase {
 
         for s in SwiftVersion.allCases {
             for p in Platform.allCases {
-                if p == .macosSpm && s == .latest {
+                if p == .macosSpm && s == .latestRelease {
                     XCTAssertEqual(
                         m.documentationTargets(platform: p, swiftVersion: s), ["t0"],
                         "failed for (\(p), \(s))"
@@ -219,7 +219,7 @@ class ManifestTests: XCTestCase {
 
         for s in SwiftVersion.allCases {
             for p in Platform.allCases {
-                if p == .ios && s == .latest {
+                if p == .ios && s == .latestRelease {
                     XCTAssertEqual(
                         m.documentationTargets(platform: p, swiftVersion: s), ["t0"],
                         "failed for (\(p), \(s))"
@@ -278,7 +278,7 @@ class ManifestTests: XCTestCase {
         for s in SwiftVersion.allCases {
             for p in Platform.allCases {
                 switch (p, s) {
-                    case (.ios, .latest), (.macosSpm, .v5_6):
+                    case (.ios, .latestRelease), (.macosSpm, .v5_6):
                         XCTAssertEqual(
                             m.documentationTargets(platform: p, swiftVersion: s), ["t0"],
                             "failed for (\(p), \(s))"
@@ -318,7 +318,8 @@ class ManifestTests: XCTestCase {
         // MUT
         XCTAssertEqual(m.documentationTargets(platform: .watchos, swiftVersion: .v5_7), ["t3"])
         XCTAssertEqual(m.documentationTargets(platform: .watchos, swiftVersion: .v5_6), nil)
-        XCTAssertEqual(m.documentationTargets(platform: .macosSpm, swiftVersion: .v5_9), ["t0"])
+        XCTAssertEqual(m.documentationTargets(platform: .macosSpm, swiftVersion: .v5_8), ["t0"])
+        XCTAssertEqual(m.documentationTargets(platform: .macosSpm, swiftVersion: .v5_9), nil)
     }
 
     func test_allDocumentationTargets() throws {
@@ -489,7 +490,7 @@ class ManifestTests: XCTestCase {
         )
 
         XCTAssertEqual(
-            m.customDocumentationParameters(platform: .macosSpm, swiftVersion: .latest),
+            m.customDocumentationParameters(platform: .macosSpm, swiftVersion: .latestRelease),
             ["--foo", "bar"]
         )
     }

--- a/Tests/SPIManifestTests/RegressionTests.swift
+++ b/Tests/SPIManifestTests/RegressionTests.swift
@@ -31,7 +31,7 @@ final class RegressionTests: XCTestCase {
         )
 
         XCTAssertEqual(
-            m.documentationTargets(platform: .macosSpm, swiftVersion: .latest),
+            m.documentationTargets(platform: .macosSpm, swiftVersion: .latestRelease),
             ["ChimeExtensionInterface", "ChimeLSPAdapter"]
         )
     }

--- a/Tests/SPIManifestTests/SwiftVersionTests.swift
+++ b/Tests/SPIManifestTests/SwiftVersionTests.swift
@@ -18,9 +18,10 @@ import XCTest
 
 class SwiftVersionTests: XCTestCase {
 
-    func test_isLatest() throws {
-        XCTAssertEqual(SwiftVersion.v5_7.isLatest, false)
-        XCTAssertEqual(SwiftVersion.v5_9.isLatest, true)
+    func test_isLatestRelease() throws {
+        XCTAssertEqual(SwiftVersion.v5_7.isLatestRelease, false)
+        XCTAssertEqual(SwiftVersion.v5_8.isLatestRelease, true)
+        XCTAssertEqual(SwiftVersion.v5_9.isLatestRelease, false)
     }
 
 }


### PR DESCRIPTION
I've run into one test case failure where a package didn't compile with Xcode 15b1 and that highlighted that we'll want to be careful not to immediately make the new version also the doc generating version.