### PR TITLE
Add Platform.init(lenientRawValue:) to support lenient inputs at the source

### DIFF
--- a/Sources/SPIManifest/Platform.swift
+++ b/Sources/SPIManifest/Platform.swift
@@ -20,4 +20,33 @@ public enum Platform: String, Codable, CaseIterable {
     case tvOS               = "tvos"
     case visionOS           = "visionos"
     case watchOS            = "watchos"
+
+
+}
+
+
+extension Platform {
+    public init?(lenientRawValue: String) {
+        // Try plain enum rawValue init
+        if let platform = Platform(rawValue: lenientRawValue) {
+            self = platform
+            return
+        }
+
+        // Support upper case variants
+        if let platform = Platform(rawValue: lenientRawValue.lowercased()) {
+            self = platform
+            return
+        }
+
+        // Support alternative spellings for macos, defaulting to macos-spm
+        switch lenientRawValue.lowercased() {
+            case "macos", "macosspm":
+                self = .macosSpm
+            case "macosxcodebuild":
+                self = .macosXcodebuild
+            default:
+                return nil
+        }
+    }
 }

--- a/Tests/SPIManifestTests/ManifestTests.swift
+++ b/Tests/SPIManifestTests/ManifestTests.swift
@@ -20,6 +20,19 @@ import Yams
 
 class ManifestTests: XCTestCase {
 
+    func test_Platform_init_lenientRawValue() throws {
+        XCTAssertEqual(Platform(lenientRawValue: "ios"), .iOS)
+        XCTAssertEqual(Platform(lenientRawValue: "iOS"), .iOS)
+        XCTAssertEqual(Platform(lenientRawValue: "iOs"), .iOS)
+        XCTAssertEqual(Platform(lenientRawValue: "macos"), .macosSpm)
+        XCTAssertEqual(Platform(lenientRawValue: "macosspm"), .macosSpm)
+        XCTAssertEqual(Platform(lenientRawValue: "macos-spm"), .macosSpm)
+        XCTAssertEqual(Platform(lenientRawValue: "macos-SPM"), .macosSpm)
+        XCTAssertEqual(Platform(lenientRawValue: "macosXcodebuild"), .macosXcodebuild)
+        XCTAssertEqual(Platform(lenientRawValue: "macosxcodebuild"), .macosXcodebuild)
+        XCTAssertEqual(Platform(lenientRawValue: "macos-xcodebuild"), .macosXcodebuild)
+    }
+
     func test_empty() throws {
         XCTAssertNoThrow(try Manifest(yml: "version: 1"))
     }


### PR DESCRIPTION
while also properly validating the input.

I just messed this up in a PR where I specified the `watchos` platform as `watchOS` (thanks, autocorrect).

The problem is that we're mapping the input to `String` in order not to reject the whole manifest in case there's a typo in one config. However, that also means our validation isn't very useful: you'll happily have this [validated correctly](https://swiftpackageindex.com/validate-spi-manifest):

![CleanShot 2023-10-08 at 13 12 02@2x](https://github.com/SwiftPackageIndex/SPIManifest/assets/65520/9d87c678-fcd0-48a3-a093-e0074e1712ea)

The problem is that when it actually comes to process a `watchos` platform this `watchOS` config won't match and the scheme selection isn't applied.