### PR TITLE
Fix validate-spi-manifest tool usage text

### DIFF
--- a/Sources/validate-spi-manifest/Validator.swift
+++ b/Sources/validate-spi-manifest/Validator.swift
@@ -11,7 +11,7 @@ enum Validator {
     static func main() {
         guard CommandLine.arguments.count == 2,
               let path = CommandLine.arguments.last else {
-            print("Usage: spi-manifest-validate <.spi.yml file>")
+            print("Usage: validate-spi-manifest <.spi.yml file>")
             exit(1)
         }
 


### PR DESCRIPTION
```
swift run spi-manifest-validate ../swift-mmio/.spi.yml
// error: no executable product named 'spi-manifest-validate'
```

```
swift run validate-spi-manifest ../swift-mmio/.spi.yml
// ✅
```