### PR TITLE
Drop 5.7

### DIFF
--- a/Sources/SPIManifest/SwiftVersion.swift
+++ b/Sources/SPIManifest/SwiftVersion.swift
@@ -16,7 +16,6 @@ public typealias ShortVersion = String
 
 
 public enum SwiftVersion: ShortVersion, Codable, CaseIterable {
-    case v5_7 = "5.7"
     case v5_8 = "5.8"
     case v5_9 = "5.9"
     case v5_10 = "5.10"

--- a/Tests/SPIManifestTests/ManifestTests.swift
+++ b/Tests/SPIManifestTests/ManifestTests.swift
@@ -322,15 +322,14 @@ class ManifestTests: XCTestCase {
                 documentation_targets:
                 - t2
               - platform: watchos
-                swift_version: 5.7
+                swift_version: 5.8
                 documentation_targets:
                 - t3
             """
         )
 
         // MUT
-        XCTAssertEqual(m.documentationTargets(platform: .watchOS, swiftVersion: .v5_7), ["t3"])
-        XCTAssertEqual(m.documentationTargets(platform: .macosSpm, swiftVersion: .v5_8), nil)
+        XCTAssertEqual(m.documentationTargets(platform: .watchOS, swiftVersion: .v5_8), ["t3"])
         XCTAssertEqual(m.documentationTargets(platform: .macosSpm, swiftVersion: .v5_9), nil)
         XCTAssertEqual(m.documentationTargets(platform: .macosSpm, swiftVersion: .v5_10), ["t0"])
         XCTAssertEqual(m.documentationTargets(platform: .watchOS, swiftVersion: .v5_9), nil)

--- a/Tests/SPIManifestTests/SwiftVersionTests.swift
+++ b/Tests/SPIManifestTests/SwiftVersionTests.swift
@@ -24,16 +24,16 @@ class SwiftVersionTests: XCTestCase {
     }
 
     func test_isLatestRelease() throws {
-        XCTAssertEqual(SwiftVersion.v5_7.isLatestRelease, false)
         XCTAssertEqual(SwiftVersion.v5_8.isLatestRelease, false)
         XCTAssertEqual(SwiftVersion.v5_9.isLatestRelease, false)
         XCTAssertEqual(SwiftVersion.v5_10.isLatestRelease, true)
+        XCTAssertEqual(SwiftVersion.v6_0.isLatestRelease, false)
     }
 
     func test_Comparable() throws {
+        XCTAssert(SwiftVersion.v6_0 > .v5_10)
         XCTAssert(SwiftVersion.v5_10 > .v5_9)
         XCTAssert(SwiftVersion.v5_9 > .v5_8)
-        XCTAssert(SwiftVersion.v5_8 > .v5_7)
     }
 
 }


### PR DESCRIPTION
We had already added Swift 6 to enable preview testing. This removes 5.7 for when we run Swift 6 builds in production, for the matrix.