### PR TITLE
Replace outdated custom doc parameter

### DIFF
--- a/Sources/SPIManifest/Documentation.docc/CommonUseCases.md
+++ b/Sources/SPIManifest/Documentation.docc/CommonUseCases.md
@@ -57,7 +57,7 @@ version: 1
 builder:
     configs:
     - documentation_targets: [Target]
-      custom_documentation_parameters: [--include-extended-types]
+      custom_documentation_parameters: [--some-custom-parameter]
 ```
 
 The provided flags will be added to the `swift package generate-documentation` call when generating documentation via SPM (default).

--- a/Sources/SPIManifest/Platform.swift
+++ b/Sources/SPIManifest/Platform.swift
@@ -20,8 +20,6 @@ public enum Platform: String, Codable, CaseIterable {
     case tvOS               = "tvos"
     case visionOS           = "visionos"
     case watchOS            = "watchos"
-
-
 }
 
 


### PR DESCRIPTION
This parameter isn't valid anymore and it seems some folks are copying it from our docs:

```
Error while generating docs: retryLimitExceeded(lastError: Optional("Shell command failed:\n    env DEVELOPER_DIR=/Applications/Xcode-15.4.0.app xcrun swift package --allow-writing-to-directory .docs/sbooth/sfbaudioengine/main generate-documentation --emit-digest --disable-indexing --output-path .docs/sbooth/sfbaudioengine/main --hosting-base-path sbooth/sfbaudioengine/main --source-service github --source-service-base-url https://github.com/sbooth/SFBAudioEngine/blob/main --checkout-path $workDir --target CSFBAudioEngine --include-extended-types"))
```

Better replace it with something that doesn't look valid.