### PR TITLE
Revert "Revert doc build to 6.0"

### DIFF
--- a/Sources/SPIManifest/SwiftVersion.swift
+++ b/Sources/SPIManifest/SwiftVersion.swift
@@ -21,7 +21,7 @@ public enum SwiftVersion: ShortVersion, Codable, CaseIterable {
     case v6_0 = "6.0"
     case v6_1 = "6.1"
 
-    public static var latestRelease: Self { .v6_0 }
+    public static var latestRelease: Self { .v6_1 }
 
     public init?(major: Int, minor: Int) {
         self.init(rawValue: "\(major).\(minor)")

--- a/Tests/SPIManifestTests/ManifestTests.swift
+++ b/Tests/SPIManifestTests/ManifestTests.swift
@@ -332,11 +332,11 @@ class ManifestTests: XCTestCase {
         for platform in Platform.allCases {
             for swiftVersion in SwiftVersion.allCases {
                 switch (platform, swiftVersion) {
-                    case (.macosSpm, .v6_0):
+                    case (.macosSpm, .v6_1):
                         XCTAssertEqual(m.documentationTargets(platform: platform, swiftVersion: swiftVersion), ["t0"])
-                    case (.iOS, .v6_0):
+                    case (.iOS, .v6_1):
                         XCTAssertEqual(m.documentationTargets(platform: platform, swiftVersion: swiftVersion), ["t1"])
-                    case (.watchOS, .v6_0):
+                    case (.watchOS, .v6_1):
                         XCTAssertEqual(m.documentationTargets(platform: platform, swiftVersion: swiftVersion), ["t2"])
                     case (.watchOS, .v5_9):
                         XCTAssertEqual(m.documentationTargets(platform: platform, swiftVersion: swiftVersion), ["t3"])

--- a/Tests/SPIManifestTests/SwiftVersionTests.swift
+++ b/Tests/SPIManifestTests/SwiftVersionTests.swift
@@ -26,8 +26,8 @@ class SwiftVersionTests: XCTestCase {
     func test_isLatestRelease() throws {
         XCTAssertEqual(SwiftVersion.v5_9.isLatestRelease, false)
         XCTAssertEqual(SwiftVersion.v5_10.isLatestRelease, false)
-        XCTAssertEqual(SwiftVersion.v6_0.isLatestRelease, true)
-        XCTAssertEqual(SwiftVersion.v6_1.isLatestRelease, false)
+        XCTAssertEqual(SwiftVersion.v6_0.isLatestRelease, false)
+        XCTAssertEqual(SwiftVersion.v6_1.isLatestRelease, true)
     }
 
     func test_Comparable() throws {


### PR DESCRIPTION
This reverts commit ff529d4a6a84bfcb854ffc2955225d0e66563536, changing the latest release back to 6.1.

Related: https://gitlab.com/finestructure/swiftpackageindex-builder/-/merge_requests/337