### PR TITLE
Added documentation for `SPI_PROCESSING`

### DIFF
--- a/Sources/SPIManifest/Documentation.docc/CommonUseCases.md
+++ b/Sources/SPIManifest/Documentation.docc/CommonUseCases.md
@@ -83,6 +83,14 @@ builder:
 
 There is also a `target:` key in order to configure a specific target instead of a scheme, where applicable.
 
+### Implementing custom package logic with SPI_PROCESSING
+
+When the Swift Package Index processes your package, you’ll find the `SPI_PROCESSING` environment variable set during two key processes:
+
+- **Analysis**: Swift Package Index extracts package metadata by running `swift package dump-package`. Packages _must_ pass analysis to be included in the index.
+- **Compatibility builds**: Swift Package Index runs either `swift build` or `xcodebuild` to determine Swift version and platform compatibility.
+
+See the [swift-java](https://swiftpackageindex.com/swiftlang/swift-java) package for an example of a package using this feature, where the authors [bypass a JDK requirement](https://github.com/swiftlang/swift-java/blob/a3791cf7c94146a34f96fd9ad53efef9d58c2a1b/Package.swift#L35) during analysis. Without this exception, the Swift Package Index analysis machines couldn’t successfully run `swift package dump-package`.
 
 ## Images for Linux
 


### PR DESCRIPTION
In the "Common Use Cases" article. It's not ideal here as this article says it's specifically about the `.spi.yml` file, but I think it's OK as this is where we talk about the build system.

<img width="1488" height="742" alt="Screenshot 2025-08-04 at 10 30 17@2x" src="https://github.com/user-attachments/assets/f317101d-7ec6-4af7-ad18-5e73d5d2940c" />
